### PR TITLE
Add quarterly report timeframe and remove email delivery

### DIFF
--- a/MyVeeamReport_config.ps1
+++ b/MyVeeamReport_config.ps1
@@ -18,8 +18,8 @@
 # VBR Server (Server Name, FQDN, IP or localhost)
 $vbrServer = $env:computername
 #$vbrServer = "lab-vbr01"
-# Report mode (RPO) - valid modes: any number of hours, Weekly or Monthly
-# 24, 48, "Weekly", "Monthly"
+# Report mode (RPO) - valid modes: any number of hours, Weekly, Monthly or Quarterly (Q1-Q4)
+# 24, 48, "Weekly", "Monthly", "Q1"
 $reportMode = 24
 # Report Title
 $rptTitle = "My Veeam Report"
@@ -52,25 +52,7 @@ $exportAllTasksBkToCSV = $true
 $setCSVDelimiter = ";"
 
 
-# Email configuration
-$sendEmail = $false
-$emailHost = "smtp.yourserver.com"
-$emailPort = 25
-$emailEnableSSL = $false
-$emailUser = ""
-$emailPass = ""
-$emailFrom = "MyVeeamReport@yourdomain.com"
-$emailTo = "you@youremail.com"
-# Send HTML report as attachment (else HTML report is body)
-$emailAttach = $false
-# Email Subject 
-$emailSubject = $rptTitle
-# Append Report Mode to Email Subject E.g. My Veeam Report (Last 24 Hours)
-$modeSubject = $true
-# Append VBR Server name to Email Subject
-$vbrSubject = $true
-# Append Date and Time to Email Subject
-$dtSubject = $false
+# Email functionality removed for manual report execution
 
 #--------------------- Disable reports you do not need by setting them to "$false" below:                                                                                        
 # Show VM Backup Protection Summary (across entire infrastructure)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Hi, this is a "little" powershell script which creates an instant configurable report about all stuff in your Veeam Backup and Replication environment. Because of my limited testlab capacity I'm only able to test with the current GA release of Veeam. Currently I'm testing with v12.
 ## What’s New
 Current version is mainly an updated version of Shawn original script and enhancements written by several people. See [Contribution](#contribution) section of this document.
+
+## Customizations in this fork
+* Added support for quarterly reporting periods (Q1-Q4) in addition to the existing hourly, weekly and monthly modes.
+* Removed email delivery logic so the report can be generated manually without SMTP configuration.
 ## Disclaimer
 The maintainer of this repository is employed by Veeam, but the maintenance and improvement of this project is not related to that. This is a pure community project, because I have fun to support something like this and have seen that many people were also very sad when Shawn stopped maintaining the project.
 ## Contribution


### PR DESCRIPTION
## Summary
- add support for quarterly (Q1-Q4) reporting by calculating explicit start and end dates
- refactor session filtering to respect the configured reporting window and drop SMTP email delivery logic
- document the manual-only focus and quarterly option in the configuration README

## Testing
- not run (environment lacks Veeam components)


------
https://chatgpt.com/codex/tasks/task_e_68cbc924424c83238d63e0c161e90365